### PR TITLE
feat(fluid-system): deploy fluid-etcd-backup-operator (FS-002)

### DIFF
--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-clusterrole.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluid-etcd-backup-operator-snapshots
+rules:
+  - apiGroups: ["k3s.cattle.io"]
+    resources: ["etcdsnapshotfiles"]
+    verbs: ["get", "list", "watch", "patch"]

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-clusterrolebinding.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluid-etcd-backup-operator-snapshots
+subjects:
+  - kind: ServiceAccount
+    name: fluid-etcd-backup-operator
+    namespace: fluid-system
+roleRef:
+  kind: ClusterRole
+  name: fluid-etcd-backup-operator-snapshots
+  apiGroup: rbac.authorization.k8s.io

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-crd.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-crd.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdoffsiterequests.fluidhq.io
+spec:
+  group: fluidhq.io
+  names:
+    categories: []
+    kind: EtcdOffsiteRequest
+    plural: etcdoffsiterequests
+    shortNames: []
+    singular: etcdoffsiterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns: []
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for EtcdOffsiteRequestSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              backupId:
+                type: string
+              nodeName:
+                type: string
+              snapshotLocation:
+                type: string
+              snapshotRef:
+                type: string
+              uploadUrl:
+                type: string
+              urlExpiresAt:
+                format: date-time
+                type: string
+            required:
+            - backupId
+            - nodeName
+            - snapshotLocation
+            - snapshotRef
+            - uploadUrl
+            - urlExpiresAt
+            type: object
+          status:
+            nullable: true
+            properties:
+              phase:
+                enum:
+                - Pending
+                - Uploading
+                - Complete
+                - Failed
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        title: EtcdOffsiteRequest
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-deployment.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fluid-etcd-backup-operator
+  labels:
+    app: fluid-etcd-backup-operator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: fluid-etcd-backup-operator
+  template:
+    metadata:
+      labels:
+        app: fluid-etcd-backup-operator
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        runAsUser: 65535
+        runAsGroup: 65535
+        fsGroup: 65535
+      containers:
+        - name: fluid-etcd-backup-operator
+          image: australia-southeast2-docker.pkg.dev/fluidhq/public/fluid-etcd-backup-operator:v0.0.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: NAMESPACE
+              value: fluid-system
+            - name: UPLOAD_IMAGE_REPOSITORY
+              value: australia-southeast2-docker.pkg.dev/fluidhq/public/fluid-etcd-upload-job
+            - name: UPLOAD_IMAGE_TAG
+              value: v0.0.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: fluid-etcd-backup-operator
+      automountServiceAccountToken: true

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-role.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fluid-etcd-backup-operator
+rules:
+  - apiGroups: ["fluidhq.io"]
+    resources: ["etcdoffsiterequests"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["fluidhq.io"]
+    resources: ["etcdoffsiterequests/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-rolebinding.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fluid-etcd-backup-operator
+subjects:
+  - kind: ServiceAccount
+    name: fluid-etcd-backup-operator
+    namespace: fluid-system
+roleRef:
+  kind: Role
+  name: fluid-etcd-backup-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/fluid-system/fluid-etcd-backup/fluid-etcd-backup-serviceaccount.yaml
+++ b/fluid-system/fluid-etcd-backup/fluid-etcd-backup-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluid-etcd-backup-operator

--- a/fluid-system/fluid-etcd-backup/kustomization.yaml
+++ b/fluid-system/fluid-etcd-backup/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - fluid-etcd-backup-crd.yaml
+  - fluid-etcd-backup-serviceaccount.yaml
+  - fluid-etcd-backup-deployment.yaml
+  - fluid-etcd-backup-clusterrole.yaml
+  - fluid-etcd-backup-clusterrolebinding.yaml
+  - fluid-etcd-backup-role.yaml
+  - fluid-etcd-backup-rolebinding.yaml

--- a/fluid-system/kustomization.yaml
+++ b/fluid-system/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - maestro
+  - fluid-etcd-backup
   - namespace.yaml
 #  - mongo
 #  - nad-syncer


### PR DESCRIPTION
## Summary

Wires the new `fluid-etcd-backup-operator` (built in [fluid-etcd-backup-operator](https://github.com/Fluid-Labs-Pty-Ltd/fluid-etcd-backup-operator)) into the cluster as a sub-component of the existing `fluid-system` ArgoCD Application — same pattern as `maestro/`. No new top-level ArgoCD Application or workflow change.

- Vendored `etcdoffsiterequests.fluidhq.io` CRD from the operator repo (`etcdoffsiterequests.fluidhq.io.yaml`, generated by `cargo run --bin crd-defs` there).
- Single-replica Deployment, image pinned to `…/fluid-etcd-backup-operator:v0.0.1`, reusing the maestro security-context profile (runAsNonRoot, readOnlyRootFilesystem, drop ALL caps, seccomp RuntimeDefault).
- Passes the operator's `UPLOAD_IMAGE_REPOSITORY` / `UPLOAD_IMAGE_TAG` env vars explicitly so spawned Jobs use `…/fluid-etcd-upload-job:v0.0.1` (the operator's defaults are local-dev placeholders).
- ClusterRole `etcdsnapshotfiles.k3s.cattle.io` → `get,list,watch,patch`. `list,watch` go beyond the literal ticket scope but are required for the kube-rs informer.
- Namespaced Role: `etcdoffsiterequests.fluidhq.io` full CRUD + `etcdoffsiterequests/status` get/update/patch + `jobs.batch` get/list/watch/create/delete.

ClickUp: [86d2wf3fw](https://app.clickup.com/t/86d2wf3fw).

## Test plan

- [x] `kubectl kustomize fluid-system/fluid-etcd-backup` renders cleanly (verified locally — all 7 resources output, CRD/ClusterRole/ClusterRoleBinding cluster-scoped, Deployment/SA/Role/RoleBinding in `fluid-system`).
- [x] `kubectl kustomize fluid-system` and `kubectl kustomize .argo-apps` render cleanly (verified locally).
- [x] Both images published in GCP Artifact Registry at `:v0.0.1`. Verified by `docker pull` (public, anonymous):
  - `fluid-etcd-backup-operator@sha256:dc823f28d794c8630aad30728ab2fc203c8a925d368a7ceaaae08aeb0b3cdf34` — `--help` confirms `NAMESPACE` / `UPLOAD_IMAGE_REPOSITORY` / `UPLOAD_IMAGE_TAG` flags match the env vars wired into the Deployment.
  - `fluid-etcd-upload-job@sha256:4eef2f3a5b7a0b577c801a87bea958210de4a0a29a2d91425395d5c25b9772b8` — `--help` shows `copy` / `upload` subcommands as expected.
- [ ] After merge to `dev`: ArgoCD `fluid-system` app reaches Synced/Healthy and `kubectl -n fluid-system logs deploy/fluid-etcd-backup-operator` shows the controller watching `EtcdOffsiteRequest`.
- [ ] `kubectl get crd etcdoffsiterequests.fluidhq.io` shows the CRD established.
- [ ] Smoke test: create a sample `EtcdOffsiteRequest`; operator should spawn a Job and (on success) patch the matching `ETCDSnapshotFile` annotation.

## Notes / follow-ups

- No readiness/liveness probe — the operator binary doesn't expose a port today.
- Rollback: ArgoCD `prune: true` will remove all workload+RBAC on revert; the CRD will linger if CRs exist (delete manually for full teardown).